### PR TITLE
Added support of server host and port customization.

### DIFF
--- a/src/generator.coffee
+++ b/src/generator.coffee
@@ -52,9 +52,10 @@ class Generator
     return callback null, @options.get('templateUrl') if @options.get('templateUrl')?
     app = express()
     app.use express.static(@options.get('templatePath'))
-    @_server = app.listen 0, (error) =>
+    options = @options.get('options')
+    @_server = app.listen options.port, (error) =>
       return callback error, null if error?
       enableDestroy @_server
-      callback null, "http://localhost:#{@_server.address().port}"
+      callback null, "http://#{options.host}:#{@_server.address().port}"
 
 module.exports = Generator

--- a/src/options.coffee
+++ b/src/options.coffee
@@ -23,7 +23,9 @@ class Options
         landscape: false
         pageSize: 'A4'
         marginsType: 0
-        printBackground: false
+        printBackground: false,
+        host: 'localhost',
+        port: 0
       renderDelay: 0
       template: 'html5bp'
 

--- a/src/options.coffee
+++ b/src/options.coffee
@@ -20,12 +20,12 @@ class Options
       throw new Error 'Missing inputPath or inputBody'
     defaults =
       options:
+        host: 'localhost'
         landscape: false
         pageSize: 'A4'
         marginsType: 0
-        printBackground: false,
-        host: 'localhost',
         port: 0
+        printBackground: false
       renderDelay: 0
       template: 'html5bp'
 

--- a/test/src/options-spec.coffee
+++ b/test/src/options-spec.coffee
@@ -19,9 +19,11 @@ describe 'Options', ->
 
       expect(@sut.options).to.deep.equal {
         options:
+          host: 'localhost'
           landscape: true
           pageSize: 'A4'
           marginsType: 0
+          port: 0
           printBackground: false
         inputBody: 'input-body'
         outputPath: path.join(__dirname, 'output')


### PR DESCRIPTION
Hi. You have the following line in your repository ```@_server = app.listen 0, (error) =>....``` Could you, please, add support of server port and host customization? Because I have to deploy my application to the cloud, but port "0", probably, is denied to access.